### PR TITLE
chore: migrate to Rust 1.95.0 and template base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -144,7 +144,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
         components: llvm-tools-preview
 
     - name: Cache cargo registry
@@ -181,10 +181,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-    - name: Install Rust 1.75.0 (MSRV)
+    - name: Install Rust 1.95.0 (MSRV)
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: 1.75.0
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -81,7 +81,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -335,7 +335,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -68,7 +68,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -99,7 +99,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -132,7 +132,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Generate changelog
       id: changelog
@@ -197,7 +197,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
         targets: ${{ matrix.target }}
 
     - name: Cache cargo registry

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -64,7 +64,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
         components: clippy
 
     - name: Cache cargo registry
@@ -108,7 +108,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
 
     - name: Cache cargo registry
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
@@ -178,7 +178,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
         components: clippy
 
     - name: Cache cargo registry
@@ -287,7 +287,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b  # v1
       with:
-        toolchain: stable
+        toolchain: 1.95.0
         components: rustfmt
 
     # Skip formatting check due to environment-specific formatting differences

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 name = "threatflux-string-analysis"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.95.0"
 authors = ["ThreatFlux Team"]
 description = "Advanced string analysis and categorization library for security applications"
 license = "MIT"

--- a/src/categorizer.rs
+++ b/src/categorizer.rs
@@ -199,7 +199,7 @@ impl DefaultCategorizer {
         });
 
         // Sort rules by priority (descending)
-        self.rules.sort_by(|a, b| b.priority.cmp(&a.priority));
+        self.rules.sort_by_key(|rule| std::cmp::Reverse(rule.priority));
     }
 }
 
@@ -227,7 +227,7 @@ impl Categorizer for DefaultCategorizer {
 
     fn add_rule(&mut self, rule: CategoryRule) -> AnalysisResult<()> {
         self.rules.push(rule);
-        self.rules.sort_by(|a, b| b.priority.cmp(&a.priority));
+        self.rules.sort_by_key(|rule| std::cmp::Reverse(rule.priority));
         Ok(())
     }
 

--- a/src/categorizer.rs
+++ b/src/categorizer.rs
@@ -199,7 +199,8 @@ impl DefaultCategorizer {
         });
 
         // Sort rules by priority (descending)
-        self.rules.sort_by_key(|rule| std::cmp::Reverse(rule.priority));
+        self.rules
+            .sort_by_key(|rule| std::cmp::Reverse(rule.priority));
     }
 }
 
@@ -227,7 +228,8 @@ impl Categorizer for DefaultCategorizer {
 
     fn add_rule(&mut self, rule: CategoryRule) -> AnalysisResult<()> {
         self.rules.push(rule);
-        self.rules.sort_by_key(|rule| std::cmp::Reverse(rule.priority));
+        self.rules
+            .sort_by_key(|rule| std::cmp::Reverse(rule.priority));
         Ok(())
     }
 

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -355,7 +355,7 @@ impl StringTracker {
             .iter()
             .map(|e| (e.value.clone(), e.total_occurrences))
             .collect();
-        most_common.sort_by(|a, b| b.1.cmp(&a.1));
+        most_common.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         most_common.truncate(100);
 
         // Suspicious strings
@@ -372,7 +372,7 @@ impl StringTracker {
             .filter(|e| e.entropy > 4.0)
             .map(|e| (e.value.clone(), e.entropy))
             .collect();
-        high_entropy_strings.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        high_entropy_strings.sort_by(|a, b| b.1.total_cmp(&a.1));
         high_entropy_strings.truncate(50);
 
         // Category distribution
@@ -503,7 +503,7 @@ impl StringTracker {
             .cloned()
             .collect();
 
-        results.sort_by(|a, b| b.total_occurrences.cmp(&a.total_occurrences));
+        results.sort_by_key(|entry| std::cmp::Reverse(entry.total_occurrences));
         results.truncate(limit);
         results
     }
@@ -526,7 +526,7 @@ impl StringTracker {
             .filter(|(_, sim)| *sim > 0.3)
             .collect();
 
-        similarities.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        similarities.sort_by(|a, b| b.1.total_cmp(&a.1));
         similarities.truncate(limit);
         similarities
     }
@@ -565,7 +565,11 @@ impl StringTracker {
         score += len_ratio;
         factors += 1.0;
 
-        if factors > 0.0 { score / factors } else { 0.0 }
+        if factors > 0.0 {
+            score / factors
+        } else {
+            0.0
+        }
     }
 
     /// Clear all tracked strings

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -62,11 +62,9 @@ fn test_suspicious_detection() {
 
     let stats = tracker.get_statistics(Some(&filter));
     assert_eq!(stats.total_unique_strings, 1);
-    assert!(
-        stats
-            .suspicious_strings
-            .contains(&"http://malware.com/payload".to_string())
-    );
+    assert!(stats
+        .suspicious_strings
+        .contains(&"http://malware.com/payload".to_string()));
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,7 @@
-use threatflux_string_analysis::{StringContext, StringFilter, StringTracker};
+use threatflux_string_analysis::{
+    Categorizer, CategoryRule, DefaultCategorizer, StringCategory, StringContext, StringFilter,
+    StringTracker,
+};
 
 #[test]
 fn test_basic_functionality() {
@@ -96,4 +99,70 @@ fn test_categorization() {
             expected_category
         );
     }
+}
+
+#[test]
+fn test_custom_categorizer_rules_are_priority_sorted() {
+    let mut categorizer = DefaultCategorizer::empty();
+
+    categorizer
+        .add_rule(CategoryRule {
+            name: "low_priority".to_string(),
+            matcher: Box::new(|value| value == "shared"),
+            category: StringCategory {
+                name: "low".to_string(),
+                parent: None,
+                description: "Low priority match".to_string(),
+            },
+            priority: 1,
+        })
+        .unwrap();
+
+    categorizer
+        .add_rule(CategoryRule {
+            name: "high_priority".to_string(),
+            matcher: Box::new(|value| value == "shared"),
+            category: StringCategory {
+                name: "high".to_string(),
+                parent: None,
+                description: "High priority match".to_string(),
+            },
+            priority: 10,
+        })
+        .unwrap();
+
+    let categories = categorizer.categorize("shared");
+    let names: Vec<_> = categories
+        .iter()
+        .map(|category| category.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["high", "low"]);
+}
+
+#[test]
+fn test_high_entropy_statistics_are_sorted_descending() {
+    let tracker = StringTracker::new();
+
+    for value in [
+        "abcdefghijklmnopqrstuvwxyz0123456789",
+        "a1B2c3D4e5F6g7H8i9J0kLmNoP",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ] {
+        tracker
+            .track_string(
+                value,
+                "/entropy.bin",
+                value,
+                "scanner",
+                StringContext::FileString { offset: None },
+            )
+            .unwrap();
+    }
+
+    let stats = tracker.get_statistics(None);
+    assert!(stats.high_entropy_strings.len() >= 2);
+    assert!(stats
+        .high_entropy_strings
+        .windows(2)
+        .all(|pair| pair[0].1 >= pair[1].1));
 }


### PR DESCRIPTION
## Summary
- Bump project baseline to Rust 1.95.0.
- Update CI/tooling and Docker base image references to `docker.io/threatflux/rust-cicd-template:base-rust-latest` / `base-rust-1.95.0` patterns where applicable.
- Apply migration updates from `chore/rust-1.95-and-deps`.

This PR is part of the repository-wide ThreatFlux Rust toolchain migration.